### PR TITLE
Fix the getMapDepthToColor() mapping issue

### DIFF
--- a/Build_libs/KinectPV2_vc2012/KinectLib_V2.0/KinectPV2.cpp
+++ b/Build_libs/KinectPV2_vc2012/KinectLib_V2.0/KinectPV2.cpp
@@ -924,6 +924,9 @@ namespace KinectPV2{
 											pointCloudPosData[cameraSpaceIndex++] = NULL;
 											pointCloudPosData[cameraSpaceIndex++] = NULL;
 
+											mapDepthToColorData[deptToColorIndex++] = NULL;
+											mapDepthToColorData[deptToColorIndex++] = NULL;
+
 											pointCloudDepthImage[depthIndex] = colorByte2Int((uint32_t)0);
 											//pointCloudDepthImage[depthIndex] = NULL;
 										}


### PR DESCRIPTION
Hello

I found out that `getMapDepthToColor()` doesn't map correctly.

At the MapDepthToColor Example the following had to be done

```
      float valX = mapDCT[count * 2 + 0];
      float valY = mapDCT[count * 2 + 1];
      int valXDepth = (int)((valX/1920.0) * 512.0);
      int valYDepth = (int)((valY/1080.0) * 424.0);
      depthToColorImg.pixels[valYDepth * 512 + valXDepth] = colorPixel;
```

This produced a resulting image but without actual mapping.
 `KinectPV2.getMapDepthToColor()` mapping doesn't actually work. If we look at the  result produced by it we'll see that the non-zero depth records are stacked at the beginning of the buffer. Then follow zeroes. If we try to map `getRawDepthData()` to `getRawColor()` using indices (not scaling) of `getMapDepthToColor()` we will not succeed.

To fix this `deptToColorIndex ` has to be incremented even if depth is out of bounds. If this is done we could map color to depth (or depth cloud) with index

I am not able to compile the cpp code to test it but it should work as expected.